### PR TITLE
корректное определение наличия плагина compose

### DIFF
--- a/start.bash
+++ b/start.bash
@@ -32,7 +32,10 @@ function dkrup() {
 
 save_version $(released_version)
 
-if [[ -f /usr/libexec/docker/cli-plugins/docker-compose ]]; then
+
+
+
+if [[ $(docker info --format='{{range .ClientInfo.Plugins}}{{if eq .Name "compose"}}true{{end}}{{end}}') = "true" ]]; then
   dkrup plugin
 else
   nonfatal die "Не обнаружен Compose V2 (плагин для docker)."


### PR DESCRIPTION
На многих дистрибутивах вроде Windows или Archlinux нет никаких лишних папок вроде /usr/libexec. В арче compose лежит в /usr/lib/docker/cli-plugins/docker-compose например. Короче говоря следует использовать собственно встроенный механизм докера для определения установленных в него расширений, чтобы потом не программировать 100500 исключений под каждую коляску