### PR TITLE
Fix running script from custom location

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
 source .common.bash
 
 checkutil git || die "Не удалось найти утилиту 'git'"

--- a/start.bash
+++ b/start.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
 source .common.bash
 
 PARALLEL="${PARALLEL:+--parallel ${PARALLEL}}"

--- a/update.bash
+++ b/update.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+
 source .common.bash
 
 lock check && die "В данный момент работает другая копия данного скрипта" \


### PR DESCRIPTION
I have a lot of error traces in my journal because script is run from the custom location. Just go to script directory before including common file to fix the issue

```
May 28 18:30:00 desktop update.bash[1560275]: /path/to/dpidetector-node/update.bash: line 3: .common.bash: No such file or directory
May 28 18:30:00 desktop update.bash[1560276]: /path/to/dpidetector-node/update.bash: line 5: lock: command not found
May 28 18:30:00 desktop update.bash[1560277]: /path/to/dpidetector-node/update.bash: line 8: lock: command not found
May 28 18:30:00 desktop update.bash[1560275]: Кажется, Вы установили данное ПО не по инструкции (скачав git-репозиторий), а из архива
May 28 18:30:00 desktop update.bash[1560275]: Работоспособность обновления при данном способе не гарантируется, но, всё же, попробуем обновить
May 28 18:30:00 desktop update.bash[1560278]: /path/to/dpidetector-node/update.bash: line 32: lock: command not found
May 28 18:30:00 desktop update.bash[1560279]: bash: install.bash: No such file or directory
May 28 18:30:00 desktop update.bash[1560280]: /path/to/dpidetector-node/update.bash: line 35: finish: command not found
```